### PR TITLE
fix: returning sibiling name, type & id to avoid duplication bug.

### DIFF
--- a/convex/files.ts
+++ b/convex/files.ts
@@ -274,9 +274,11 @@ export const renameFile = mutation({
 
     const existing = siblings.find(
       (sibling) =>
-        sibling.name === args.newName &&
-        sibling.type === file.type &&
-        sibling._id !== args.id
+         return (
+        sibiling.name === args.newName &&
+        sibiling.type === file.type &&
+        sibiling._id !== args.id
+      );
     );
 
     if (existing) {


### PR DESCRIPTION
As we don't return the existing name, type and id here, it is allowing the user to rename multiple files of the same name at the same level. Hence just by return the existing data, we could trigger an error on the db level so that user can't rename a file with incorrect way.

Continuing the tutorial ahead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue affecting file rename functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->