### PR TITLE
fix: returning existing details to avoid duplicate names after renaming

### DIFF
--- a/convex/files.ts
+++ b/convex/files.ts
@@ -274,9 +274,11 @@ export const renameFile = mutation({
 
     const existing = siblings.find(
       (sibling) =>
+        return(
         sibling.name === args.newName &&
         sibling.type === file.type &&
         sibling._id !== args.id
+        )
     );
 
     if (existing) {


### PR DESCRIPTION
As we don't return the existing sibling metadata like name, type and id, convex isn't blocking the user to have multiple files of same name at the same level. 

Hence I have only returned the metadata so that user is blocked during renaming & rules of File Explorer stays perfect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file renaming functionality to improve error handling.

* **Style**
  * Applied minor formatting improvements to file operations code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->