### PR TITLE
fix: renaming duplication bug

### DIFF
--- a/convex/files.ts
+++ b/convex/files.ts
@@ -33,7 +33,7 @@ export const getFile = query({
 
     const file = await ctx.db.get("files", args.id);
 
-     if (!file) {
+    if (!file) {
       throw new Error("File not found");
     }
 
@@ -84,7 +84,7 @@ export const getFilePath = query({
     let currentId: Id<"files"> | undefined = args.id;
 
     while (currentId) {
-      const file = (await ctx.db.get("files", currentId)) as 
+      const file = (await ctx.db.get("files", currentId)) as
         | Doc<"files">
         | undefined;
       if (!file) break;
@@ -98,7 +98,7 @@ export const getFilePath = query({
 });
 
 export const getFolderContents = query({
-  args: { 
+  args: {
     projectId: v.id("projects"),
     parentId: v.optional(v.id("files")),
   },
@@ -118,9 +118,7 @@ export const getFolderContents = query({
     const files = await ctx.db
       .query("files")
       .withIndex("by_project_parent", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("parentId", args.parentId)
+        q.eq("projectId", args.projectId).eq("parentId", args.parentId),
       )
       .collect();
 
@@ -137,7 +135,7 @@ export const getFolderContents = query({
 });
 
 export const createFile = mutation({
-  args: { 
+  args: {
     projectId: v.id("projects"),
     parentId: v.optional(v.id("files")),
     name: v.string(),
@@ -160,14 +158,12 @@ export const createFile = mutation({
     const files = await ctx.db
       .query("files")
       .withIndex("by_project_parent", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("parentId", args.parentId)
+        q.eq("projectId", args.projectId).eq("parentId", args.parentId),
       )
       .collect();
 
     const existing = files.find(
-      (file) => file.name === args.name && file.type === "file"
+      (file) => file.name === args.name && file.type === "file",
     );
 
     if (existing) throw new Error("File already exists");
@@ -190,7 +186,7 @@ export const createFile = mutation({
 });
 
 export const createFolder = mutation({
-  args: { 
+  args: {
     projectId: v.id("projects"),
     parentId: v.optional(v.id("files")),
     name: v.string(),
@@ -212,14 +208,12 @@ export const createFolder = mutation({
     const files = await ctx.db
       .query("files")
       .withIndex("by_project_parent", (q) =>
-        q
-          .eq("projectId", args.projectId)
-          .eq("parentId", args.parentId)
+        q.eq("projectId", args.projectId).eq("parentId", args.parentId),
       )
       .collect();
 
     const existing = files.find(
-      (file) => file.name === args.name && file.type === "folder"
+      (file) => file.name === args.name && file.type === "folder",
     );
 
     if (existing) throw new Error("Folder already exists");
@@ -266,22 +260,21 @@ export const renameFile = mutation({
     const siblings = await ctx.db
       .query("files")
       .withIndex("by_project_parent", (q) =>
-        q
-          .eq("projectId", file.projectId)
-          .eq("parentId", file.parentId)
+        q.eq("projectId", file.projectId).eq("parentId", file.parentId),
       )
       .collect();
 
-    const existing = siblings.find(
-      (sibling) =>
+    const existing = siblings.find((sibling) => {
+      return (
         sibling.name === args.newName &&
         sibling.type === file.type &&
         sibling._id !== args.id
-    );
+      );
+    });
 
     if (existing) {
       throw new Error(
-        `A ${file.type} with this name already exists in this location`
+        `A ${file.type} with this name already exists in this location`,
       );
     }
 
@@ -296,7 +289,7 @@ export const renameFile = mutation({
     await ctx.db.patch("projects", file.projectId, {
       updatedAt: now,
     });
-  }
+  },
 });
 
 export const deleteFile = mutation({
@@ -329,23 +322,21 @@ export const deleteFile = mutation({
       }
 
       // If it's a folder, delete all children first
-       if (item.type === "folder") {
-         const children = await ctx.db
+      if (item.type === "folder") {
+        const children = await ctx.db
           .query("files")
           .withIndex("by_project_parent", (q) =>
-            q
-              .eq("projectId", item.projectId)
-              .eq("parentId", fileId)
+            q.eq("projectId", item.projectId).eq("parentId", fileId),
           )
           .collect();
 
-          for (const child of children) {
-            await deleteRecursive(child._id);
-          }
-       }
+        for (const child of children) {
+          await deleteRecursive(child._id);
+        }
+      }
 
-       // Delete storage file if it exists
-       if (item.storageId) {
+      // Delete storage file if it exists
+      if (item.storageId) {
         await ctx.storage.delete(item.storageId);
       }
 
@@ -358,7 +349,7 @@ export const deleteFile = mutation({
     await ctx.db.patch("projects", file.projectId, {
       updatedAt: Date.now(),
     });
-  }
+  },
 });
 
 export const updateFile = mutation({


### PR DESCRIPTION
As we don't return the existing metadata of the user, on renaming this allows the user to have 2 files of the same name on the same level which is actually against the rules of the file explorer.

We are trying to restricting  the user by not allowing them to create 2 files with the same name on the same level. Hence while renaming too, it shouldn't be able to do so. Hence I have just returned the existing metadata so that Convex can easily block the user while reanaming.


<img width="539" height="219" alt="Screenshot 2026-02-09 at 7 48 18 PM" src="https://github.com/user-attachments/assets/1bbc3450-c660-46d9-bd7f-64402efa9fa8" />

PS: I am not sure if this PR get's merged or not but I did this because you are putting so much effort & hence I wanted to give this back to you showing that in times of AI, I am still learning from you & I care for all the efforts you made for the video ❤️