### PR TITLE
fix - not saving editor state to convex when closing/ moving to other…

### DIFF
--- a/src/features/editor/components/editor-view.tsx
+++ b/src/features/editor/components/editor-view.tsx
@@ -33,7 +33,7 @@ export const EditorView = ({ projectId }: { projectId: Id<"projects"> }) => {
         pendingContentRef.current = null;
       }
     };
-  }, [activeTabId, activeFile, updateFile]);
+  }, [activeTabId]);
 
   return (
     <div className="h-full flex flex-col">

--- a/src/features/editor/components/editor-view.tsx
+++ b/src/features/editor/components/editor-view.tsx
@@ -28,12 +28,14 @@ export const EditorView = ({ projectId }: { projectId: Id<"projects"> }) => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-      if (pendingContentRef.current && activeFile) {
-        updateFile({ id: activeFile._id, content: pendingContentRef.current });
+      if (pendingContentRef.current !== null && activeTabId) {
+        updateFile({ id: activeTabId, content: pendingContentRef.current });
         pendingContentRef.current = null;
       }
     };
-  }, [activeTabId]);
+  }, [
+    activeTabId  
+  ]);
 
   return (
     <div className="h-full flex flex-col">

--- a/src/features/editor/components/editor-view.tsx
+++ b/src/features/editor/components/editor-view.tsx
@@ -17,6 +17,7 @@ export const EditorView = ({ projectId }: { projectId: Id<"projects"> }) => {
   const activeFile = useFile(activeTabId);
   const updateFile = useUpdateFile();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingContentRef = useRef<string | null>(null);
 
   const isActiveFileBinary = activeFile && activeFile.storageId;
   const isActiveFileText = activeFile && !activeFile.storageId;
@@ -27,8 +28,12 @@ export const EditorView = ({ projectId }: { projectId: Id<"projects"> }) => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
+      if (pendingContentRef.current && activeFile) {
+        updateFile({ id: activeFile._id, content: pendingContentRef.current });
+        pendingContentRef.current = null;
+      }
     };
-  }, [activeTabId]);
+  }, [activeTabId, activeFile, updateFile]);
 
   return (
     <div className="h-full flex flex-col">
@@ -54,12 +59,15 @@ export const EditorView = ({ projectId }: { projectId: Id<"projects"> }) => {
             fileName={activeFile.name}
             initialValue={activeFile.content}
             onChange={(content: string) => {
+              pendingContentRef.current = content;
+
               if (timeoutRef.current) {
                 clearTimeout(timeoutRef.current);
               }
 
               timeoutRef.current = setTimeout(() => {
                 updateFile({ id: activeFile._id, content });
+                pendingContentRef.current = null;
               }, DEBOUNCE_MS);
             }}
           />


### PR DESCRIPTION
### Issue
When a user edits a file and switches to another file before the debounce timeout (1500ms) completes, the pending changes are lost without being saved to Convex.

### Root Cause
The useEffect cleanup function was clearing the debounce timer when activeTabId changed, but it wasn't flushing the pending content before clearing the timeout. This resulted in unsaved edits being discarded.

### Steps to Reproduce

- Open a file in the editor
- Type some text
- Immediately switch to another file (before 1.5 seconds pass)
- Observe: Changes are lost and not saved to Convex

### Solution

- Added pendingContentRef to track unsaved content changes
- Modified the cleanup function to flush pending changes to Convex before clearing the timeout
- Ensures all edits are persisted when switching files or unmounting the component

### Changes

- Track pending content in a ref while debouncing
- Save pending content before clearing the timer in useEffect cleanup
- Clear the pending content ref after successfully updating
- This prevents accidental data loss while maintaining the debounce optimization for database updates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor auto-save: edits are now debounced to reduce redundant saves while typing, and any unsaved edits are committed immediately when switching tabs or closing the editor.
  * This ensures recent changes are preserved reliably and reduces unexpected lost work during normal use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->